### PR TITLE
Expose as a module

### DIFF
--- a/bin/barkeep
+++ b/bin/barkeep
@@ -1,49 +1,9 @@
 #!/usr/bin/env node
 
-var tinylr = require('tiny-lr');
-var express = require('express');
-var Gaze = require('gaze').Gaze;
-var open = require('open');
-var cors = require('cors');
-var path = require('path');
-var inject = require('../src/inject.js');
-var urlCallback = require('../src/url-callback.js');
+var barkeep = require('..');
 
-var root = process.cwd();
-var staticPort = 9000;
-var lrPort = 35729;
+barkeep(process.cwd()).listen(9000, 35729, onListening);
 
-var server = tinylr();
-var app = express();
-var gaze = new Gaze(null, { debounceDelay: 200 });
-var watchedFiles = [];
-
-app
-  .use(cors())
-  .use(inject('http://localhost:35729/livereload.js'))
-  .use(urlCallback(addToGaze))
-  .use(express.static(root))
-  .listen(staticPort, openBrowser);
-
-server.listen(lrPort);
-
-function addToGaze(url) {
-  // If it's a directory, add index.html to the end
-  if (/\/$/.test(url)) {
-    url += 'index.html';
-  }
-
-  if (watchedFiles.indexOf(url) === -1) {
-    watchedFiles.push(url);
-    gaze.add(path.join(root, url));
-    console.log('Added:', url, 'to list of watched files');
-  }
-}
-
-gaze.on('changed', function(filepath) {
-  server.changed({ body: { files: filepath.replace(root, '') } });
-});
-
-function openBrowser() {
-  open('http://localhost:' + staticPort);
+function onListening() {
+  console.log('Listening at http://localhost:9000');
 }

--- a/index.js
+++ b/index.js
@@ -1,0 +1,54 @@
+var tinylr = require('tiny-lr');
+var express = require('express');
+var Gaze = require('gaze').Gaze;
+var cors = require('cors');
+var path = require('path');
+
+var inject = require('./src/inject.js');
+var urlCallback = require('./src/url-callback.js');
+
+function Barkeep(root) {
+  this._addToGaze = this._addToGaze.bind(this);
+  this.root = root;
+  this.server = tinylr();
+  this.app = express();
+  this.gaze = new Gaze(null, { debounceDelay: 200 });
+  this.watchedFiles = [];
+}
+
+module.exports = function barkeep(root) {
+  return new Barkeep(root);
+};
+
+Barkeep.prototype.listen = function(staticPort, lrPort, done) {
+  var self = this;
+  staticPort = staticPort || 9000;
+  lrPort = lrPort || 35729;
+
+  this.server.listen(lrPort);
+
+  this.gaze.on('changed', function(filepath) {
+    self.server.changed({ body: { files: filepath.replace(self.root, '') } });
+  });
+
+  return this.app
+    .use(cors())
+    .use(inject('http://localhost:' + lrPort + '/livereload.js'))
+    .use(urlCallback(this._addToGaze))
+    .use(express.static(this.root))
+    .listen(staticPort, done);
+};
+
+Barkeep.prototype._addToGaze = function(url) {
+  // If it's a directory, add index.html to the end
+  if (/\/$/.test(url)) {
+    url += 'index.html';
+  }
+
+  if (this.watchedFiles.indexOf(url) === -1) {
+    this.watchedFiles.push(url);
+    this.gaze.add(path.join(this.root, url));
+    console.log('Added:', url, 'to list of watched files');
+  }
+};
+

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "barkeep",
   "version": "0.1.0",
   "description": "Serve the contents of a directory and livereload those that change.",
+  "main": "index.js",
   "bin": {
     "barkeep": "./bin/barkeep"
   },


### PR DESCRIPTION
barkeep in two flavours:

cli:

```
$ ../node_modules/.bin/barkeep
Listening at http://localhost:9000
Added: /index.html to list of watched files
Added: /test.js to list of watched files
Added: /test.map to list of watched files
```

or api:

``` js
var root = __dirname; // serve files from here
var sp = 9000;            // optional static port
var lp = 35729;           // optional livereload port

var server = barkeep(root).listen(sp, lp, onListen);

// optional callback
function onListen() {
  console.log('listening');
}
```
