### PR TITLE
Absolutely resolve passed root directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function Barkeep(root) {
   }
 
   this._addToGaze = this._addToGaze.bind(this);
-  this.root = root;
+  this.root = path.resolve(root);
   this.server = tinylr();
   this.app = express();
   this.gaze = new Gaze(null, { debounceDelay: 200 });


### PR DESCRIPTION
`filepath.replace(this.root, '')` fails if `this.root` is relative. Fixed by resolving the passed `root` directory to an absolute path.
